### PR TITLE
Added setting a public const string with the AssemblyVersion value.

### DIFF
--- a/task/ApplyAssemblyInfo.ps1
+++ b/task/ApplyAssemblyInfo.ps1
@@ -154,6 +154,7 @@ Function NetFramework() {
         # set version
         if(![string]::IsNullOrWhiteSpace($Version)) {
             $filecontent -replace "AssemblyVersion\($WordRegex\)", "AssemblyVersion(`"$Version`")" | Out-File $file
+            $filecontent -replace "public const string AssemblyVersion = $WordRegex", "public const string AssemblyVersion =`"$Version`"" | Out-File $file
             $filecontent = Get-Content($file)
         }
 


### PR DESCRIPTION
Hi Bleddyn,

I have created a slight variant of your Assembly Info task that as well as setting the AssemblyInfo attribute value, it sets a const public string on a class. This allows us to use the same value elsewhere were we need a const string at compile time and cannot ready the Assembly Info attribute at runtime.

Is this something you'd consider including in your build?

Many thanks

Colin