### PR TITLE
Excluding Tests Folder

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,5 @@
 # Release Notes
-> **v2.1.81**
+> **v2.1.85**
 > - Added date transforms for all fields.
 > - Enhanced logging options.
 > - Added Application Insights.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "test": "npm run build && mocha dist/tests/_suite.js",
     "testrunner": "npm run build && TestRunner.sh",
     "gen_notice": "node generate-third-party-notice.js",
-    "nuke_install": "rm -rf node_modules dist && npm cache verify && npm install"
+    "nuke_install": "rm -rf node_modules dist && npm cache verify && npm install",
+    "package-release": "tfx extension create --manifest-globs ./vss-extension.json",
+    "package-dev": "tfx extension create --manifest-globs ./vss-extension.json --share-with bleddynrichards"
   },
   "repository": {
     "type": "git",
@@ -26,6 +28,7 @@
   "homepage": "https://github.com/BMuuN/vsts-assemblyinfo-task#readme",
   "dependencies": {
     "@types/chardet": "^0.8.0",
+    "@types/q": "^1.5.2",
     "@types/xml2js": "^0.4.5",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.9.3",
@@ -37,7 +40,6 @@
   "devDependencies": {
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.12.14",
-    "@types/q": "^1.5.2",
     "mocha": "^6.2.2",
     "ts-node": "^8.5.4",
     "typescript": "^3.7.2"

--- a/package.json
+++ b/package.json
@@ -2,10 +2,6 @@
   "name": "vsts-assemblyinfo-task",
   "version": "1.0.0",
   "description": "Extension for Team Services that sets assembly information from a build.",
-  "main": "index.js",
-  "directories": {
-    "test": "test"
-  },
   "scripts": {
     "build": "tsc",
     "start": "node dist/src/task/index.js",
@@ -13,6 +9,7 @@
     "testrunner": "npm run build && TestRunner.sh",
     "gen_notice": "node generate-third-party-notice.js",
     "nuke_install": "rm -rf node_modules dist && npm cache verify && npm install",
+    "nuke_install_prod": "rm -rf node_modules dist && npm cache verify && npm install --production",
     "package-release": "tfx extension create --manifest-globs ./vss-extension.json",
     "package-dev": "tfx extension create --manifest-globs ./vss-extension.json --share-with bleddynrichards"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -57,6 +57,7 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "tests"
   ]
 }


### PR DESCRIPTION
Excluding the `tests` folder as the pipeline is `FUBAR`ed: - the package size is now >25Mb and we can no longer publish to the marketplace as we're exceeding the maximum package size.  The size is bloated by the `node_modules` dir and we therefore have to trim it down, starting with the tests :(