### PR TITLE
Add ignoreNetFrameworkProjects for .net core task

### DIFF
--- a/src/netcore/index.ts
+++ b/src/netcore/index.ts
@@ -106,6 +106,7 @@ function getDefaultModel(): models.NetCore {
 
         logLevel: tl.getInput('LogLevel', true) || '',
         failOnWarning: tl.getBoolInput('FailOnWarning', true),
+        ignoreNetFrameworkProjects: tl.getBoolInput('IgnoreNetFrameworkProjects', false) || false,
     };
 
     return model;
@@ -215,6 +216,8 @@ function setManifestData(model: models.NetCore, regEx: models.RegEx): void {
 
             // Ensure the project is tartgeting .Net Core or .Net Standard
             if (!result.Project.$.Sdk || result.Project.$.Sdk.indexOf('Microsoft.NET.Sdk') < 0) {
+                if (model.ignoreNetFrameworkProjects) return;
+                
                 logger.warning(`Project is not targeting .Net Core or .Net Standard, moving to next file.`);
                 logger.info('');
                 return;

--- a/src/netcore/models/assembly-info.model.ts
+++ b/src/netcore/models/assembly-info.model.ts
@@ -20,4 +20,5 @@ export abstract class AssemblyInfo {
 
     logLevel: string = '';
     failOnWarning: boolean = false;
+    ignoreNetFrameworkProjects: boolean = false;
 }

--- a/src/netcore/task.json
+++ b/src/netcore/task.json
@@ -299,6 +299,15 @@
       "required": true,
       "helpMarkDown": "If checked the task will disable Application Insights telemetry.",
       "groupName": "loggingGroup"
+    },
+    {
+      "name": "IgnoreNetFrameworkProjects",
+      "type": "boolean",
+      "label": "Ignore .Net Framework Projects",
+      "defaultValue": false,
+      "required": false,
+      "helpMarkDown": "If checked no warning will be written for .Net Framework projects.",
+      "groupName": "loggingGroup"
     }
   ],
   "execution": {


### PR DESCRIPTION
When specified this disables the warning in the logs for .NET framework projects.