### PR TITLE
Adding Feature for Tagging Builds

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -6,6 +6,8 @@
 > - The build will now fail when no source files are found.
 > - Started to add unit test coverage.
 > - Added output variables to task GUI.
+> - Added "Tagging Group" to tag the builds and update build number.
+> Thanks to [andyste1](https://github.com/andyste1)
 > - Added support for `MSBuild.Sdk.Extras` projects.
 > Thanks to [crb04c](https://github.com/crb04c)
 

--- a/src/netcore/index.ts
+++ b/src/netcore/index.ts
@@ -38,12 +38,8 @@ async function run() {
         generateVersionNumbers(model, regExModel);
         printTaskParameters(model);
         setManifestData(model, regExModel);
-
-        // set output variables
-        tl.setVariable('AssemblyInfo.Version', model.version, false);
-        tl.setVariable('AssemblyInfo.FileVersion', model.fileVersion, false);
-        tl.setVariable('AssemblyInfo.InformationalVersion', model.informationalVersion, false);
-        tl.setVariable('AssemblyInfo.PackageVersion', model.packageVersion, false);
+        setOutputVariables(model);
+        setTaggingOptions(model);
 
         logger.success('Complete.');
 
@@ -108,6 +104,9 @@ function getDefaultModel(): models.NetCore {
         logLevel: tl.getInput('LogLevel', true) || '',
         failOnWarning: tl.getBoolInput('FailOnWarning', true),
         ignoreNetFrameworkProjects: tl.getBoolInput('IgnoreNetFrameworkProjects', false) || false,
+
+        buildNumber: tl.getInput('UpdateBuildNumber', false) || '',
+        buildTag: tl.getInput('AddBuildTag', false) || '',
     };
 
     return model;
@@ -172,6 +171,9 @@ function printTaskParameters(model: models.NetCore): void {
 
     logger.debug(`Log Level: ${model.logLevel}`);
     logger.debug(`Fail on Warning: ${model.failOnWarning}`);
+
+    logger.debug(`Build Tag: ${model.buildTag}`);
+    logger.debug(`Build Number: ${model.buildNumber}`);
 
     logger.debug('');
 }
@@ -543,6 +545,24 @@ function setAssemblyData(group: any, model: models.NetCore): void {
             group.InformationalVersion = model.informationalVersion;
             logger.info(`InformationalVersion --> ${model.informationalVersion}`);
         }
+    }
+}
+
+function setOutputVariables(model: models.NetCore) {
+    tl.setVariable('Version', model.version, false);
+    tl.setVariable('FileVersion', model.fileVersion, false);
+    tl.setVariable('InformationalVersion', model.informationalVersion, false);
+    tl.setVariable('PackageVersion', model.packageVersion, false);
+}
+
+function setTaggingOptions(model: models.NetCore) {
+
+    if (model.buildNumber) {
+        tl.updateBuildNumber(model.buildNumber);
+    }
+
+    if (model.buildTag) {
+        tl.addBuildTag(model.buildTag);
     }
 }
 

--- a/src/netcore/models/assembly-info.model.ts
+++ b/src/netcore/models/assembly-info.model.ts
@@ -21,4 +21,7 @@ export abstract class AssemblyInfo {
     logLevel: string = '';
     failOnWarning: boolean = false;
     ignoreNetFrameworkProjects: boolean = false;
+
+    buildTag: string = '';
+    buildNumber: string = '';
 }

--- a/src/netcore/task.json
+++ b/src/netcore/task.json
@@ -32,6 +32,11 @@
       "name": "loggingGroup",
       "displayName": "Logging",
       "isExpanded": false
+    },
+    {
+      "name": "taggingGroup",
+      "displayName": "Tagging",
+      "isExpanded": false
     }
   ],
   "inputs": [{
@@ -318,23 +323,41 @@
       "required": false,
       "helpMarkDown": "If checked no warning will be written for .Net Framework projects.",
       "groupName": "loggingGroup"
+    },
+    {
+      "name": "UpdateBuildNumber",
+      "type": "string",
+      "label": "Update Build Number",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "If set will update the build number on task completion.  Usually set to $(AssemblyInfo.Version)",
+      "groupName": "taggingGroup"
+    },
+    {
+      "name": "AddBuildTag",
+      "type": "string",
+      "label": "Add Build Tag",
+      "defaultValue": "$(AssemblyInfo.Version)",
+      "required": false,
+      "helpMarkDown": "If set will tag the commit. Usually set to $(AssemblyInfo.Version)",
+      "groupName": "taggingGroup"
     }
   ],
   "OutputVariables": [
     {
-      "name": "AssemblyInfo.Version",
+      "name": "Version",
       "description": "Is set with the calculated version number."
     },
     {
-      "name": "AssemblyInfo.FileVersion",
+      "name": "FileVersion",
       "description": "Is set with the calculated file version number."
     },
     {
-      "name": "AssemblyInfo.InformationalVersion",
+      "name": "InformationalVersion",
       "description": "Is set with the calculated informational version number."
     },
     {
-      "name": "AssemblyInfo.PackageVersion",
+      "name": "PackageVersion",
       "description": "Is set with the calculated package version number."
     }
   ],

--- a/src/netframework/index.ts
+++ b/src/netframework/index.ts
@@ -37,10 +37,8 @@ async function run() {
         generateVersionNumbers(model, regExModel);
         printTaskParameters(model);
         setManifestData(model, regExModel);
-
-        tl.setVariable('AssemblyInfo.Version', model.version, false);
-        tl.setVariable('AssemblyInfo.FileVersion', model.fileVersion, false);
-        tl.setVariable('AssemblyInfo.InformationalVersion', model.informationalVersion, false);
+        setOutputVariables(model);
+        setTaggingOptions(model);
 
         logger.success('Complete.');
 
@@ -93,6 +91,9 @@ function getDefaultModel(): models.NetFramework {
 
         logLevel: tl.getInput('LogLevel', true) || '',
         failOnWarning: tl.getBoolInput('FailOnWarning', true),
+
+        buildNumber: tl.getInput('UpdateBuildNumber', false) || '',
+        buildTag: tl.getInput('AddBuildTag', false) || '',
     };
 
     return model;
@@ -145,6 +146,9 @@ function printTaskParameters(model: models.NetFramework): void {
 
     logger.debug(`Log Level: ${model.logLevel}`);
     logger.debug(`Fail on Warning: ${model.failOnWarning}`);
+
+    logger.debug(`Build Tag: ${model.buildTag}`);
+    logger.debug(`Build Number: ${model.buildNumber}`);
 
     logger.debug('');
 }
@@ -285,6 +289,23 @@ function replaceAttribute(content: string, name: string, regEx: string, value: s
     logger.info(`${name} --> ${value}`);
     content = content.replace(new RegExp(`${name}\\s*\\w*\\(${regEx}\\)`, 'gi'), `${name}("${value}")`);
     return content;
+}
+
+function setOutputVariables(model: models.NetFramework) {
+    tl.setVariable('Version', model.version, false);
+    tl.setVariable('FileVersion', model.fileVersion, false);
+    tl.setVariable('InformationalVersion', model.informationalVersion, false);
+}
+
+function setTaggingOptions(model: models.NetFramework) {
+
+    if (model.buildNumber) {
+        tl.updateBuildNumber(model.buildNumber);
+    }
+
+    if (model.buildTag) {
+        tl.addBuildTag(model.buildTag);
+    }
 }
 
 run();

--- a/src/netframework/models/assembly-info.model.ts
+++ b/src/netframework/models/assembly-info.model.ts
@@ -20,4 +20,7 @@ export abstract class AssemblyInfo {
 
     logLevel: string = '';
     failOnWarning: boolean = false;
+
+    buildTag: string = '';
+    buildNumber: string = '';
 }

--- a/src/netframework/task.json
+++ b/src/netframework/task.json
@@ -32,6 +32,11 @@
       "name": "loggingGroup",
       "displayName": "Logging",
       "isExpanded": false
+    },
+    {
+      "name": "taggingGroup",
+      "displayName": "Tagging",
+      "isExpanded": false
     }
   ],
   "inputs": [{
@@ -219,19 +224,37 @@
       "required": true,
       "helpMarkDown": "If checked the task will disable Application Insights telemetry.",
       "groupName": "loggingGroup"
+    },
+    {
+      "name": "UpdateBuildNumber",
+      "type": "string",
+      "label": "Update Build Number",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "If set will update the build number on task completion.  Usually set to $(AssemblyInfo.Version)",
+      "groupName": "taggingGroup"
+    },
+    {
+      "name": "AddBuildTag",
+      "type": "string",
+      "label": "Add Build Tag",
+      "defaultValue": "$(AssemblyInfo.Version)",
+      "required": false,
+      "helpMarkDown": "If set will tag the commit. Usually set to $(AssemblyInfo.Version)",
+      "groupName": "taggingGroup"
     }
   ],
   "OutputVariables": [
     {
-      "name": "AssemblyInfo.Version",
+      "name": "Version",
       "description": "Is set with the calculated version number."
     },
     {
-      "name": "AssemblyInfo.FileVersion",
+      "name": "FileVersion",
       "description": "Is set with the calculated file version number."
     },
     {
-      "name": "AssemblyInfo.InformationalVersion",
+      "name": "InformationalVersion",
       "description": "Is set with the calculated informational version number."
     }
   ],


### PR DESCRIPTION
- Added new "Tagging" group
- Added options to update build name
- Added option to tag a build
- Altered `OutputVariables` names as per schema recommendation