### PR TITLE
Removing Obsolete Category

### DIFF
--- a/src/vss-extension.json
+++ b/src/vss-extension.json
@@ -15,7 +15,7 @@
         "default": "images/Logo128x128.png"
     },
     "categories": [
-        "Build and release"
+        "Azure Pipelines"
     ],
     "tags": [
         "Build",


### PR DESCRIPTION
Removing the obsolete category "Build and release" and replacing it with "Azure Pipelines"